### PR TITLE
Release notes for version 2.0.8

### DIFF
--- a/github.json
+++ b/github.json
@@ -10,7 +10,7 @@
     "product_version_regex": ".*",
     "publisher": "Splunk",
     "license": "Copyright (c) 2019-2022 Splunk Inc.",
-    "app_version": "2.0.6",
+    "app_version": "2.0.8",
     "python_version": "3",
     "fips_compliant": true,
     "utctime_updated": "2021-04-28T23:08:45.000000Z",

--- a/release_notes/2.0.8.md
+++ b/release_notes/2.0.8.md
@@ -1,0 +1,6 @@
+**GitHub Release Notes - Published by Splunk January 21, 2022**
+
+
+**Version 2.0.8 - Released January 21, 2022**
+
+* Marked the app as FIPS Compliant [PAPP-22681]

--- a/release_notes/release_notes.html
+++ b/release_notes/release_notes.html
@@ -1,5 +1,9 @@
 <b>GitHub Release Notes - Published by Splunk June 07, 2021</b>
 <br><br>
+<b>Version 2.0.8 - Released January 21, 2021</b>
+<ul>
+<li>Marked the app as FIPS Compliant [PAPP-22681]</li>
+</ul>
 <b>Version 2.0.7 - Released June 07, 2021</b>
 <ul>
 <li>Fixed handling of symbolic links when loading app state [PAPP-16267]</li>

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,1 @@
 **Unreleased**
-* Marked the app as FIPS Compliant [PAPP-22681]


### PR DESCRIPTION
### Notes
- `start-release` and the build job against `next` are failing due to https://api.github.com/repos/splunk-soar-connectors/github/contents/github.json?ref=next
- manually incrementing the app version to `2.0.8` - the app version in `main` is currently `2.0.7`
- manually creating release notes for `2.0.8`