### PR TITLE
fix: preserve action metadata with SDK 4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.16.3
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.44.2
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.89.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         language_version: python3.13
@@ -62,7 +62,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.6
+    rev: v2.2.9
     hooks:
       - id: build-docs
         language: python

--- a/NOTICE
+++ b/NOTICE
@@ -3408,7 +3408,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 @@@@============================================================================
 
-Library: splunk-soar-sdk - 4.0.0
+Library: splunk-soar-sdk - 4.1.1
 Homepage: https://github.com/phantomcyber/splunk-soar-sdk
 License: Apache-2.0
 License Text:

--- a/NOTICE
+++ b/NOTICE
@@ -3408,7 +3408,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 @@@@============================================================================
 
-Library: splunk-soar-sdk - 4.1.1
+Library: splunk-soar-sdk - 4.1.2
 Homepage: https://github.com/phantomcyber/splunk-soar-sdk
 License: Apache-2.0
 License Text:

--- a/NOTICE
+++ b/NOTICE
@@ -4,7 +4,7 @@ Third Party Software Attributions:
 
 @@@@============================================================================
 
-Library: Authlib - 1.7.2
+Library: Authlib - 1.7.1
 Homepage: https://github.com/authlib/authlib
 License: BSD License
 License Text:
@@ -350,36 +350,6 @@ whether future versions of the GNU Lesser General Public License shall
 apply, that proxy's public statement of acceptance of any version is
 permanent authorization for you to choose that version for the
 Library.
-
-
-@@@@============================================================================
-
-Library: annotated-doc - 0.0.4
-Homepage: https://github.com/fastapi/annotated-doc
-License: MIT
-License Text:
-
-The MIT License (MIT)
-
-Copyright (c) 2025 Sebastián Ramírez
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
 
 
 @@@@============================================================================
@@ -3388,7 +3358,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 @@@@============================================================================
 
-Library: rich - 15.0.0
+Library: rich - 14.3.4
 Homepage: https://github.com/Textualize/rich
 License: MIT License
 License Text:
@@ -3438,7 +3408,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 @@@@============================================================================
 
-Library: splunk-soar-sdk - 3.22.2
+Library: splunk-soar-sdk - 4.0.0
 Homepage: https://github.com/phantomcyber/splunk-soar-sdk
 License: Apache-2.0
 License Text:
@@ -3951,9 +3921,9 @@ License Text:
 
 @@@@============================================================================
 
-Library: typer - 0.26.7
+Library: typer - 0.17.5
 Homepage: https://github.com/fastapi/typer
-License: MIT
+License: MIT License
 License Text:
 
 The MIT License (MIT)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13, <3.15"
 authors = [
 ]
 dependencies = [
-    "splunk-soar-sdk>=3.22.2",
+    "splunk-soar-sdk>=4.0.0",
 ]
 
 [tool.soar.app]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13, <3.15"
 authors = [
 ]
 dependencies = [
-    "splunk-soar-sdk>=4.0.0",
+    "splunk-soar-sdk>=4.1.1",
 ]
 
 [tool.soar.app]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13, <3.15"
 authors = [
 ]
 dependencies = [
-    "splunk-soar-sdk>=4.1.1",
+    "splunk-soar-sdk>=4.1.2",
 ]
 
 [tool.soar.app]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* - Updated the Splunk SOAR SDK dependency to version 4.0.0 while preserving existing action read-only declarations.
+* Updated the Splunk SOAR SDK dependency to version 4.0.0 while preserving existing action read-only declarations.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* - Updated the Splunk SOAR SDK dependency to version 4.0.0 while preserving existing action read-only declarations.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Updated the Splunk SOAR SDK dependency to version 4.1.1 while preserving existing action read-only declarations.
+* Updated the Splunk SOAR SDK dependency to version 4.1.2 while preserving existing action read-only declarations.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Updated the Splunk SOAR SDK dependency to version 4.0.0 while preserving existing action read-only declarations.
+* Updated the Splunk SOAR SDK dependency to version 4.1.1 while preserving existing action read-only declarations.

--- a/src/actions/__init__.py
+++ b/src/actions/__init__.py
@@ -86,12 +86,14 @@ def register_actions(app: App) -> App:
         description="Retrieve an issue for the GitHub repository",
         action_type="investigate",
         render_as="table",
+        read_only=True,
     )
     app.register_action(
         action=list_comments,
         description="List comments for an issue on the GitHub repository",
         action_type="investigate",
         render_as="table",
+        read_only=True,
     )
     app.register_action(
         action=list_events,
@@ -99,36 +101,42 @@ def register_actions(app: App) -> App:
         action_type="investigate",
         verbose="Action will list a maximum of 300 events. Only events from the past 90 days will be listed.",
         render_as="table",
+        read_only=True,
     )
     app.register_action(
         action=list_issues,
         description="Get a list of issues for the GitHub repository",
         action_type="investigate",
         render_as="table",
+        read_only=True,
     )
     app.register_action(
         action=list_organizations,
         description="List all organizations",
         action_type="investigate",
         render_as="table",
+        read_only=True,
     )
     app.register_action(
         action=list_repos,
         description="List all repos of an organization",
         action_type="investigate",
         render_as="table",
+        read_only=True,
     )
     app.register_action(
         action=list_teams,
         description="List all teams of an organization",
         action_type="investigate",
         render_as="table",
+        read_only=True,
     )
     app.register_action(
         action=list_users,
         description="List users of an organization",
         action_type="investigate",
         render_as="table",
+        read_only=True,
     )
     app.register_action(
         action=remove_collaborator,

--- a/uv.lock
+++ b/uv.lock
@@ -364,7 +364,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "splunk-soar-sdk", specifier = ">=4.0.0" }]
+requires-dist = [{ name = "splunk-soar-sdk", specifier = ">=4.1.1" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1025,7 +1025,7 @@ wheels = [
 
 [[package]]
 name = "splunk-soar-sdk"
-version = "4.0.0"
+version = "4.1.1"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
     { name = "authlib", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1051,9 +1051,9 @@ dependencies = [
     { name = "tqdm", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/6a/4adf0c158f9115d2d2d519733bb85ae81af64a30003e97a2af0bedf556f3/splunk_soar_sdk-4.0.0.tar.gz", hash = "sha256:0ac59fa65465fd5538875d7a0d71cf09d5acfc95e24d3a3f9b82e721e0c95a7c", size = 764337, upload-time = "2026-08-15T00:13:02.768Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/ba/c847187945099f9995b2674f85813dbf4ed6b402d0648ad423adf617b62d/splunk_soar_sdk-4.1.1.tar.gz", hash = "sha256:01bb4fe7b56f1fead8a20d1e51ccb67e250a7eb6e5d6c89ae22e7f68252098b8", size = 765773, upload-time = "2026-08-21T21:49:59.41Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/bb/23f193f5e439e8a8ffdc760e7d8a51320d8072447a9eeb1650b897e6daa9/splunk_soar_sdk-4.0.0-py3-none-any.whl", hash = "sha256:00fa45dd902aeacf9e2cce2c940a415cd5169d38c3d313d4b733c88fa243d9f8", size = 223539, upload-time = "2026-08-15T00:13:01.156Z" },
+    { url = "https://files.pythonhosted.org/packages/95/89/3c13205daac227f659cd2678357a04643c899e990f8ed2d0d0bb095cd80e/splunk_soar_sdk-4.1.1-py3-none-any.whl", hash = "sha256:4bd8aee96031f459711aad824fcd601a284ec26b4a883a8c47cabd792a036ac5", size = 224221, upload-time = "2026-08-21T21:49:58.051Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -364,7 +364,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "splunk-soar-sdk", specifier = ">=4.1.1" }]
+requires-dist = [{ name = "splunk-soar-sdk", specifier = ">=4.1.2" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1025,7 +1025,7 @@ wheels = [
 
 [[package]]
 name = "splunk-soar-sdk"
-version = "4.1.1"
+version = "4.1.2"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
     { name = "authlib", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1051,9 +1051,9 @@ dependencies = [
     { name = "tqdm", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/ba/c847187945099f9995b2674f85813dbf4ed6b402d0648ad423adf617b62d/splunk_soar_sdk-4.1.1.tar.gz", hash = "sha256:01bb4fe7b56f1fead8a20d1e51ccb67e250a7eb6e5d6c89ae22e7f68252098b8", size = 765773, upload-time = "2026-08-21T21:49:59.41Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/05/7a667c605445278f221dd0d1aa429b491c97842d5c087af68df8b26ac5f3/splunk_soar_sdk-4.1.2.tar.gz", hash = "sha256:3eca2e908727035d1bfbaa9c1c1eb9585e93b3fe7b3ed40900d3b63fa018a342", size = 765856, upload-time = "2026-08-21T22:57:24.905Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/89/3c13205daac227f659cd2678357a04643c899e990f8ed2d0d0bb095cd80e/splunk_soar_sdk-4.1.1-py3-none-any.whl", hash = "sha256:4bd8aee96031f459711aad824fcd601a284ec26b4a883a8c47cabd792a036ac5", size = 224221, upload-time = "2026-08-21T21:49:58.051Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c5/e0a6297bf1cbecfb36c4d4cd82b2010a4f9a0520846bfd500507046f4670/splunk_soar_sdk-4.1.2-py3-none-any.whl", hash = "sha256:ddff56d12640d8df0d4bbc0697f88f2cfb20a8a0ef3934a57e2cbed665212ce4", size = 224295, upload-time = "2026-08-21T22:57:23.755Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -27,15 +27,6 @@ required-markers = [
 ]
 
 [[package]]
-name = "annotated-doc"
-version = "0.0.4"
-source = { registry = "https://pypi.python.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
-]
-
-[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.python.org/simple" }
@@ -58,15 +49,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.7.2"
+version = "1.7.1"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
     { name = "cryptography", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "joserfc", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/f2/e05664d5275ce811fd4e9df0a2b3f0086ee19a8a80358d95499fa82fd50c/authlib-1.7.1.tar.gz", hash = "sha256:8c09b0f9d080c823e594b52316af70f79a1fa4eed64d0363a076233c04ef063a", size = 175884, upload-time = "2026-05-04T08:11:25.033Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/82/730650ee5e5b598b7bfdc291b784bc2f6fe02a5671695485403365101088/authlib-1.7.1-py2.py3-none-any.whl", hash = "sha256:8470f4aa6b5590ac41bd81d6e6ee12448ce36a0da0af19bbed69fb53fb4e8ad9", size = 258826, upload-time = "2026-05-04T08:11:23.208Z" },
 ]
 
 [[package]]
@@ -355,7 +346,7 @@ wheels = [
 
 [[package]]
 name = "github"
-version = "3.0.0"
+version = "3.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "splunk-soar-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -373,7 +364,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "splunk-soar-sdk", specifier = ">=3.22.2" }]
+requires-dist = [{ name = "splunk-soar-sdk", specifier = ">=4.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -967,15 +958,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "15.0.0"
+version = "14.3.4"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
     { name = "markdown-it-py", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pygments", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
 ]
 
 [[package]]
@@ -1034,7 +1025,7 @@ wheels = [
 
 [[package]]
 name = "splunk-soar-sdk"
-version = "3.22.2"
+version = "4.0.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
     { name = "authlib", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1054,14 +1045,15 @@ dependencies = [
     { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pyjwt", extra = ["crypto"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "requests", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "rich", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "setuptools", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "toml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tqdm", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/f8/f5de958238eee1b72400d69e74da1b72e4e8f24ee11e31309a4a87909ee3/splunk_soar_sdk-3.22.2.tar.gz", hash = "sha256:e42b97c15c7ff3c8c33ea15ac13918b66a78ed212738bb97c4d274c956c0f74c", size = 669665, upload-time = "2026-06-09T16:56:46.398Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/6a/4adf0c158f9115d2d2d519733bb85ae81af64a30003e97a2af0bedf556f3/splunk_soar_sdk-4.0.0.tar.gz", hash = "sha256:0ac59fa65465fd5538875d7a0d71cf09d5acfc95e24d3a3f9b82e721e0c95a7c", size = 764337, upload-time = "2026-08-15T00:13:02.768Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/ea/5d32699c7b949bd16f67ef4015e95855edb6a4102f7e9b6b57c877f264ab/splunk_soar_sdk-3.22.2-py3-none-any.whl", hash = "sha256:8a1ea3e38af13fe2302503d8b709873877522e4698b7c423ffd16a318dda55e9", size = 210008, upload-time = "2026-06-09T16:56:47.495Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/bb/23f193f5e439e8a8ffdc760e7d8a51320d8072447a9eeb1650b897e6daa9/splunk_soar_sdk-4.0.0-py3-none-any.whl", hash = "sha256:00fa45dd902aeacf9e2cce2c940a415cd5169d38c3d313d4b733c88fa243d9f8", size = 223539, upload-time = "2026-08-15T00:13:01.156Z" },
 ]
 
 [[package]]
@@ -1093,16 +1085,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.26.7"
+version = "0.17.5"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "annotated-doc", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "click", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "rich", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "shellingham", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/3e/30bff313f4868538330c6254bbbe178d6143e43c6f3e7a34788d381f701c/typer-0.17.5.tar.gz", hash = "sha256:a6fe2d187feb1b4a10322b910267b6339e4cc98257fae34d22299a47eac704f1", size = 103790, upload-time = "2025-09-19T18:34:31.292Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/1d/0e129c8cf45b22f9b56250ff40cac9f5d1535b2d33294dcfcb3a7e8f3299/typer-0.17.5-py3-none-any.whl", hash = "sha256:45f2709d44be2f0d0f8bc70c9f845f60ef69d6cc80c6e6ae2cc2f29bae650cf6", size = 46650, upload-time = "2025-09-19T18:34:28.737Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Bug Fixes

- Updates the Splunk SOAR SDK dependency to 4.0.0 and preserves existing action metadata with explicit `read_only=True` declarations where it was previously implicit.

### Manual Documentation

- [x] No manual documentation changes are required.

### Other information

Validation: `uv lock --upgrade-package splunk-soar-sdk` and `pre-commit run --all-files`.

Written by Codex.
