### PR TITLE
feat: add GitHub App (installation) authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **personal_access_token** | optional | password | Personal Access Token (PAT) |
 **client_id** | optional | string | OAuth App Client ID |
 **client_secret** | optional | password | OAuth App Client Secret |
+**app_id** | optional | string | GitHub App ID |
+**app_private_key** | optional | password | GitHub App private key (PEM format) |
+**app_installation_id** | optional | string | GitHub App installation ID |
 
 ### Supported Actions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 dependencies = [
     "splunk-soar-sdk>=3.22.2",
+    "pyjwt[crypto]>=2.8.0",
 ]
 
 [tool.soar.app]

--- a/src/actions/test_connectivity.py
+++ b/src/actions/test_connectivity.py
@@ -21,7 +21,7 @@ from soar_sdk.exceptions import ActionFailure
 from soar_sdk.logging import getLogger
 
 from ..asset import Asset
-from ..auth import complete_oauth_authorization
+from ..auth import complete_oauth_authorization, has_github_app_config
 from ..client import call_github
 from ..consts import (
     GITHUB_CONFIG_PARAMS_REQUIRED,
@@ -47,15 +47,17 @@ def run_test_connectivity(
 ) -> None:
     """Validate the asset configuration for connectivity using supplied configuration.
 
-    Supports both credential styles:
+    Supports all three credential styles:
       * Personal Access Token — probes GET /user directly.
+      * GitHub App (app_id/app_private_key/app_installation_id) — exchanges an
+        installation token and probes GET /user directly.
       * OAuth App (client_id/client_secret) — runs the authorization code flow
         (prompting the user to authorize in a browser) before probing GET /user.
     """
 
     logger.progress("Starting connectivity test")
 
-    if not asset.personal_access_token:
+    if not asset.personal_access_token and not has_github_app_config(asset):
         _authorize_oauth(soar, asset, app=app)
 
     # GET /user is the canonical connectivity probe.

--- a/src/asset.py
+++ b/src/asset.py
@@ -23,3 +23,10 @@ class Asset(BaseAsset):
     client_secret: str | None = AssetField(
         description="OAuth App Client Secret", sensitive=True
     )
+    app_id: str | None = AssetField(description="GitHub App ID")
+    app_private_key: str | None = AssetField(
+        description="GitHub App private key (PEM format)", sensitive=True
+    )
+    app_installation_id: str | None = AssetField(
+        description="GitHub App installation ID"
+    )

--- a/src/auth.py
+++ b/src/auth.py
@@ -13,21 +13,27 @@
 # limitations under the License.
 # Authentication for the GitHub app, built entirely on soar_sdk.auth.
 #
-# GitHub supports two credential styles:
+# GitHub supports three credential styles:
 #   1. Personal Access Token (PAT) — a static bearer token.
 #   2. OAuth App (client_id / client_secret) — the authorization code flow,
 #      with tokens persisted in the SDK-managed asset.auth_state.
+#   3. GitHub App (app_id / app_private_key / app_installation_id) — a
+#      short-lived JWT signed with the App's private key is exchanged for an
+#      installation access token, which is cached until shortly before expiry.
 #
 # resolve_github_auth() picks between them and returns an httpx.Auth that
 # call_github() hands directly to httpx.Client(auth=...).
 
 from __future__ import annotations
 
+import datetime
+import re
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from typing import TYPE_CHECKING
 
 import httpx
+import jwt as pyjwt
 
 from soar_sdk.auth import (
     OAuthBearerAuth,
@@ -40,8 +46,18 @@ from soar_sdk.exceptions import ActionFailure
 
 from .consts import (
     DEFAULT_TIMEOUT,
+    GITHUB_API_BASE_URL,
+    GITHUB_APP_INSTALLATION_TOKEN_FAILED_MSG,
+    GITHUB_APP_INSTALLATION_TOKEN_MISSING_MSG,
+    GITHUB_APP_INVALID_PEM_FORMAT_MSG,
+    GITHUB_APP_INVALID_PEM_PUBLIC_KEY_MSG,
+    GITHUB_APP_JWT_EXP_SECONDS,
+    GITHUB_APP_JWT_GENERATION_FAILED_MSG,
+    GITHUB_APP_JWT_IAT_BACKDATE_SECONDS,
+    GITHUB_APP_TOKEN_EXPIRY_BUFFER,
     GITHUB_AUTHORIZE_ENDPOINT,
     GITHUB_CONFIG_PARAMS_REQUIRED,
+    GITHUB_ENDPOINT_APP_INSTALLATION_TOKEN,
     GITHUB_OAUTH_FAILED_MSG,
     GITHUB_SCOPE,
     GITHUB_TC_STATUS_SLEEP,
@@ -54,6 +70,11 @@ if TYPE_CHECKING:
 # How long test_connectivity waits (in seconds) for the user to complete the
 # browser authorization step before giving up.
 _OAUTH_POLL_TIMEOUT = 300
+
+# Pre-compiled patterns used to validate/normalize the GitHub App private key.
+_PEM_PUBLIC_KEY_RE = re.compile(r"-----BEGIN (?:RSA )?PUBLIC KEY-----")
+_PEM_PRIVATE_KEY_HEADER_RE = re.compile(r"-----BEGIN (?:\w+ )*PRIVATE KEY-----")
+_PEM_PRIVATE_KEY_FOOTER_RE = re.compile(r"-----END (?:\w+ )*PRIVATE KEY-----")
 
 
 def build_pat_auth(asset: Asset) -> StaticTokenAuth:
@@ -153,19 +174,154 @@ def complete_oauth_authorization(
     )
 
 
+def generate_github_app_jwt(asset: Asset) -> str:
+    """Generate a signed JWT for GitHub App authentication (RS256).
+
+    The JWT is built per GitHub's App authentication spec:
+      * iat: issued ~60 seconds in the past to compensate for clock drift.
+      * exp: 9 minutes from now (GitHub enforces a 10-minute maximum).
+      * iss: the App ID.
+
+    Raises ValueError if the private key is missing, a public key, or
+    otherwise not a valid PEM private key.
+    """
+    key_str = asset.app_private_key or ""
+
+    # Strip a UTF-8 BOM if present.
+    key_str = key_str.lstrip("\ufeff")
+
+    # Normalize literal "\n" escape sequences (two characters) to real newlines.
+    if "\\n" in key_str:
+        key_str = key_str.replace("\\n", "\n")
+
+    key_str = key_str.strip()
+
+    if _PEM_PUBLIC_KEY_RE.search(key_str):
+        raise ValueError(GITHUB_APP_INVALID_PEM_PUBLIC_KEY_MSG)
+
+    if not (
+        _PEM_PRIVATE_KEY_HEADER_RE.search(key_str)
+        and _PEM_PRIVATE_KEY_FOOTER_RE.search(key_str)
+    ):
+        raise ValueError(GITHUB_APP_INVALID_PEM_FORMAT_MSG)
+
+    now = int(time.time())
+    payload = {
+        "iat": now - GITHUB_APP_JWT_IAT_BACKDATE_SECONDS,
+        "exp": now + GITHUB_APP_JWT_EXP_SECONDS,
+        "iss": asset.app_id,
+    }
+    return pyjwt.encode(payload, key_str.encode("utf-8"), algorithm="RS256")
+
+
+class GitHubAppAuth(httpx.Auth):
+    """HTTPX authentication for a GitHub App installation.
+
+    Exchanges a short-lived JWT (signed with the App's private key) for an
+    installation access token via POST /app/installations/{id}/access_tokens,
+    and caches it until shortly before it expires.
+    """
+
+    def __init__(self, asset: Asset) -> None:
+        self._asset = asset
+        self._token: str | None = None
+        self._expires_at: datetime.datetime | None = None
+
+    def _token_is_valid(self) -> bool:
+        if not (self._token and self._expires_at):
+            return False
+        buffer = datetime.timedelta(seconds=GITHUB_APP_TOKEN_EXPIRY_BUFFER)
+        return datetime.datetime.now(datetime.UTC) < self._expires_at - buffer
+
+    def _fetch_installation_token(self) -> str:
+        try:
+            jwt_token = generate_github_app_jwt(self._asset)
+        except ValueError:
+            raise
+        except Exception as exc:
+            raise ActionFailure(
+                f"{GITHUB_APP_JWT_GENERATION_FAILED_MSG} Details: {exc}"
+            ) from exc
+
+        endpoint = GITHUB_ENDPOINT_APP_INSTALLATION_TOKEN.format(
+            installation_id=self._asset.app_installation_id
+        )
+        url = f"{GITHUB_API_BASE_URL}{endpoint}"
+        headers = {
+            "Authorization": f"Bearer {jwt_token}",
+            "Accept": "application/vnd.github+json",
+        }
+
+        try:
+            with httpx.Client(timeout=DEFAULT_TIMEOUT) as client:
+                response = client.post(url, headers=headers)
+        except httpx.RequestError as exc:
+            raise ActionFailure(f"Error connecting to GitHub API: {exc}") from exc
+
+        if response.status_code >= 400:
+            raise ActionFailure(
+                f"{GITHUB_APP_INSTALLATION_TOKEN_FAILED_MSG}: "
+                f"HTTP {response.status_code} — {response.text}"
+            )
+
+        data = response.json()
+        token = data.get("token")
+        if not token:
+            raise ActionFailure(GITHUB_APP_INSTALLATION_TOKEN_MISSING_MSG)
+
+        expires_at_str = data.get("expires_at", "")
+        try:
+            self._expires_at = datetime.datetime.fromisoformat(
+                expires_at_str.replace("Z", "+00:00")
+            )
+        except (ValueError, AttributeError):
+            self._expires_at = datetime.datetime.now(datetime.UTC) + datetime.timedelta(
+                hours=1
+            )
+
+        self._token = token
+        return token
+
+    def auth_flow(
+        self,
+        request: httpx.Request,
+    ) -> Generator[httpx.Request, httpx.Response]:
+        """Add the installation access token to the request, refreshing as needed."""
+        if not self._token_is_valid():
+            self._fetch_installation_token()
+
+        request.headers["Authorization"] = f"Bearer {self._token}"
+        yield request
+
+
+def build_github_app_auth(asset: Asset) -> GitHubAppAuth:
+    """Return SDK-compatible bearer auth backed by a GitHub App installation token."""
+    return GitHubAppAuth(asset)
+
+
 def resolve_github_auth(asset: Asset) -> httpx.Auth:
     """Return the correct httpx.Auth for the configured asset credentials.
 
     Priority order:
       1. personal_access_token (PAT)          → StaticTokenAuth
-      2. client_id / client_secret (OAuth App) → OAuthBearerAuth (auth_state)
+      2. app_id / app_private_key / app_installation_id (GitHub App)
+                                               → GitHubAppAuth (installation token)
+      3. client_id / client_secret (OAuth App) → OAuthBearerAuth (auth_state)
 
-    Raises ActionFailure when neither credential set is present.
+    Raises ActionFailure when no credential set is present.
     """
     if asset.personal_access_token:
         return build_pat_auth(asset)
+
+    if asset.app_id and asset.app_private_key and asset.app_installation_id:
+        return build_github_app_auth(asset)
 
     if asset.client_id and asset.client_secret:
         return build_oauth_auth(asset)
 
     raise ActionFailure(GITHUB_CONFIG_PARAMS_REQUIRED)
+
+
+def has_github_app_config(asset: Asset) -> bool:
+    """Return True if GitHub App credentials are fully configured on the asset."""
+    return bool(asset.app_id and asset.app_private_key and asset.app_installation_id)

--- a/src/consts.py
+++ b/src/consts.py
@@ -15,6 +15,9 @@
 GITHUB_CONFIG_CLIENT_ID = "client_id"
 GITHUB_CONFIG_CLIENT_SECRET = "client_secret"  # pragma: allowlist secret  # noqa: S105
 GITHUB_CONFIG_AUTH_TOKEN = "personal_access_token"  # noqa: S105
+GITHUB_CONFIG_APP_ID = "app_id"
+GITHUB_CONFIG_APP_PRIVATE_KEY = "app_private_key"  # pragma: allowlist secret
+GITHUB_CONFIG_APP_INSTALLATION_ID = "app_installation_id"
 GITHUB_JSON_REPO_OWNER = "repo_owner"
 GITHUB_JSON_REPO_NAME = "repo_name"
 GITHUB_JSON_ISSUE_NUMBER = "issue_number"
@@ -30,6 +33,9 @@ GITHUB_ENDPOINT_COMMENTS = (
 )
 GITHUB_ENDPOINT_GET_ISSUE = "/repos/{repo_owner}/{repo_name}/issues/{issue_number}"
 GITHUB_ENDPOINT_LABELS = "/repos/{repo_owner}/{repo_name}/issues/{issue_number}/labels"
+GITHUB_ENDPOINT_APP_INSTALLATION_TOKEN = (
+    "/app/installations/{installation_id}/access_tokens"  # noqa: S105
+)
 GITHUB_INVALID_INTEGER = 'Please provide non-zero positive integer in "{parameter}"'
 GITHUB_MAKING_CONNECTION_MSG = "Connecting to an endpoint"
 GITHUB_TEST_CONNECTIVITY_FAILED_MSG = "Test connectivity failed"
@@ -44,10 +50,12 @@ GITHUB_MEMBER_REMOVAL_MSG = (
     'Member with username "{user_name}" successfully removed from Team "{team}"'
 )
 GITHUB_CONFIG_PARAMS_REQUIRED_CONNECTIVITY = (
-    "A 'personal_access_token' is required for test connectivity"
+    "A 'personal_access_token' or 'client_id'/'client_secret' or "
+    "'app_id'/'app_private_key'/'app_installation_id' is required for test connectivity"
 )
 GITHUB_CONFIG_PARAMS_REQUIRED = (
-    "Please provide a 'personal_access_token' in the asset configuration"
+    "Please provide a 'personal_access_token', or 'client_id' and 'client_secret', or "
+    "'app_id', 'app_private_key', and 'app_installation_id' in the asset configuration"
 )
 GITHUB_BASE_URL_NOT_FOUND_MSG = "Phantom Base URL not found in System Settings. Please specify the value in System Settings"
 GITHUB_OAUTH_URL_MSG = "Using OAuth URL:"
@@ -163,3 +171,29 @@ GITHUB_PAGINATION_MAX_PAGES = 1000
 GITHUB_TC_STATUS_SLEEP = 3
 GITHUB_AUTHORIZE_WAIT_TIME = 15
 DEFAULT_TIMEOUT = 30  # seconds
+
+# GitHub App (installation) authentication
+GITHUB_APP_JWT_IAT_BACKDATE_SECONDS = 60
+GITHUB_APP_JWT_EXP_SECONDS = 540  # 9 minutes; GitHub enforces a 10-minute maximum
+GITHUB_APP_TOKEN_EXPIRY_BUFFER = 300  # seconds
+GITHUB_APP_JWT_GENERATION_FAILED_MSG = (
+    "Failed to generate GitHub App JWT. Please verify 'app_private_key' is a "
+    "valid PEM-encoded RSA private key."
+)
+GITHUB_APP_INVALID_PEM_PUBLIC_KEY_MSG = (
+    "The 'app_private_key' value appears to be a public key. Please re-download "
+    "the private key from your GitHub App's settings page and paste the full "
+    "contents of the .pem file."
+)
+GITHUB_APP_INVALID_PEM_FORMAT_MSG = (
+    "The 'app_private_key' value does not appear to be a valid PEM private key. "
+    "Expected a string containing a '-----BEGIN RSA PRIVATE KEY-----' or "
+    "'-----BEGIN PRIVATE KEY-----' header and a matching "
+    "'-----END ... PRIVATE KEY-----' footer."
+)
+GITHUB_APP_INSTALLATION_TOKEN_FAILED_MSG = (
+    "Failed to obtain GitHub App installation access token"  # noqa: S105
+)
+GITHUB_APP_INSTALLATION_TOKEN_MISSING_MSG = (
+    "GitHub API response did not contain an installation access token"  # noqa: S105
+)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,258 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for GitHub App (installation) authentication."""
+
+import datetime
+from unittest.mock import Mock
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from soar_sdk.exceptions import ActionFailure
+
+from src import auth as auth_module
+from src.auth import (
+    GitHubAppAuth,
+    generate_github_app_jwt,
+    has_github_app_config,
+    resolve_github_auth,
+)
+
+
+def _generate_test_rsa_key_pair() -> str:
+    """Generate a temporary RSA-2048 private key (PEM) for test use only."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+
+
+def _make_asset(**overrides):
+    defaults = {
+        "personal_access_token": None,
+        "client_id": None,
+        "client_secret": None,
+        "app_id": "12345",
+        "app_private_key": _generate_test_rsa_key_pair(),
+        "app_installation_id": "67890",
+    }
+    defaults.update(overrides)
+    return Mock(**defaults)
+
+
+class TestGenerateGithubAppJwt:
+    def test_jwt_has_three_parts(self):
+        asset = _make_asset()
+        token = generate_github_app_jwt(asset)
+        assert len(token.split(".")) == 3
+
+    def test_jwt_uses_rs256_algorithm(self):
+        asset = _make_asset()
+        token = generate_github_app_jwt(asset)
+        header = jwt.get_unverified_header(token)
+        assert header["alg"] == "RS256"
+
+    def test_jwt_claims_iss_equals_app_id(self):
+        asset = _make_asset()
+        token = generate_github_app_jwt(asset)
+        payload = jwt.decode(token, options={"verify_signature": False})
+        assert payload["iss"] == "12345"
+
+    def test_jwt_exp_after_iat_within_ten_minutes(self):
+        asset = _make_asset()
+        now = int(datetime.datetime.now(datetime.UTC).timestamp())
+        token = generate_github_app_jwt(asset)
+        payload = jwt.decode(token, options={"verify_signature": False})
+        assert payload["exp"] > payload["iat"]
+        assert payload["exp"] <= now + 600 + 1
+
+    def test_jwt_signature_verifiable(self):
+        private_pem = _generate_test_rsa_key_pair()
+        asset = _make_asset(app_private_key=private_pem)
+        private_key_obj = load_pem_private_key(private_pem.encode(), None)
+        public_key = private_key_obj.public_key()
+
+        token = generate_github_app_jwt(asset)
+        decoded = jwt.decode(token, public_key, algorithms=["RS256"])
+        assert decoded["iss"] == "12345"
+
+    def test_pem_with_literal_escaped_newlines_parses_successfully(self):
+        private_pem = _generate_test_rsa_key_pair()
+        collapsed = private_pem.replace("\n", "\\n")
+        asset = _make_asset(app_private_key=collapsed)
+        token = generate_github_app_jwt(asset)
+        assert len(token.split(".")) == 3
+
+    def test_pem_with_leading_trailing_whitespace_parses_successfully(self):
+        private_pem = _generate_test_rsa_key_pair()
+        asset = _make_asset(app_private_key="\n\n  " + private_pem + "  \n\n")
+        token = generate_github_app_jwt(asset)
+        assert len(token.split(".")) == 3
+
+    def test_pem_with_bom_parses_successfully(self):
+        private_pem = _generate_test_rsa_key_pair()
+        asset = _make_asset(app_private_key="\ufeff" + private_pem)
+        token = generate_github_app_jwt(asset)
+        assert len(token.split(".")) == 3
+
+    def test_public_key_produces_specific_error(self):
+        private_pem = _generate_test_rsa_key_pair()
+        private_key_obj = load_pem_private_key(private_pem.encode(), None)
+        public_pem = (
+            private_key_obj.public_key()
+            .public_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            .decode("utf-8")
+        )
+
+        asset = _make_asset(app_private_key=public_pem)
+        with pytest.raises(ValueError, match="public key"):
+            generate_github_app_jwt(asset)
+
+    def test_garbage_string_produces_generic_invalid_pem_error(self):
+        asset = _make_asset(app_private_key="this-is-not-a-pem-key-at-all")
+        with pytest.raises(ValueError, match="PRIVATE KEY"):
+            generate_github_app_jwt(asset)
+
+
+class TestGitHubAppAuth:
+    _FAKE_TOKEN = "ghs_fake_installation_token"
+    _EXPIRES_IN_1H = (
+        datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=1)
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def _mock_post_response(
+        self, monkeypatch, *, status_code=201, token=None, expires_at=None
+    ):
+        response = Mock(status_code=status_code)
+        response.json.return_value = {
+            "token": token or self._FAKE_TOKEN,
+            "expires_at": expires_at or self._EXPIRES_IN_1H,
+        }
+        response.text = ""
+        client = Mock()
+        client.post.return_value = response
+        client.__enter__ = Mock(return_value=client)
+        client.__exit__ = Mock(return_value=False)
+        monkeypatch.setattr(auth_module.httpx, "Client", Mock(return_value=client))
+        return client
+
+    def test_exchanges_jwt_for_installation_token(self, monkeypatch):
+        asset = _make_asset()
+        self._mock_post_response(monkeypatch)
+        github_app_auth = GitHubAppAuth(asset)
+
+        token = github_app_auth._fetch_installation_token()
+
+        assert token == self._FAKE_TOKEN
+        assert github_app_auth._token == self._FAKE_TOKEN
+        assert github_app_auth._expires_at is not None
+
+    def test_reuses_cached_token_while_valid(self, monkeypatch):
+        asset = _make_asset()
+        github_app_auth = GitHubAppAuth(asset)
+        github_app_auth._token = self._FAKE_TOKEN
+        github_app_auth._expires_at = datetime.datetime.now(
+            datetime.UTC
+        ) + datetime.timedelta(hours=1)
+
+        client_cls = Mock()
+        monkeypatch.setattr(auth_module.httpx, "Client", client_cls)
+
+        request = Mock(headers={})
+        generator = github_app_auth.auth_flow(request)
+        next(generator)
+
+        client_cls.assert_not_called()
+        assert request.headers["Authorization"] == f"Bearer {self._FAKE_TOKEN}"
+
+    def test_refreshes_nearly_expired_token(self, monkeypatch):
+        asset = _make_asset()
+        github_app_auth = GitHubAppAuth(asset)
+        github_app_auth._token = "almost_expired_token"
+        github_app_auth._expires_at = datetime.datetime.now(
+            datetime.UTC
+        ) + datetime.timedelta(minutes=2)
+
+        self._mock_post_response(monkeypatch, token="ghs_fresh_token")
+
+        request = Mock(headers={})
+        generator = github_app_auth.auth_flow(request)
+        next(generator)
+
+        assert request.headers["Authorization"] == "Bearer ghs_fresh_token"
+
+    def test_raises_action_failure_on_api_error(self, monkeypatch):
+        asset = _make_asset()
+        self._mock_post_response(monkeypatch, status_code=401)
+        github_app_auth = GitHubAppAuth(asset)
+
+        with pytest.raises(ActionFailure):
+            github_app_auth._fetch_installation_token()
+
+    def test_raises_action_failure_when_token_missing(self, monkeypatch):
+        asset = _make_asset()
+        response = Mock(status_code=201)
+        response.json.return_value = {"expires_at": self._EXPIRES_IN_1H}
+        response.text = ""
+        client = Mock()
+        client.post.return_value = response
+        client.__enter__ = Mock(return_value=client)
+        client.__exit__ = Mock(return_value=False)
+        monkeypatch.setattr(auth_module.httpx, "Client", Mock(return_value=client))
+
+        github_app_auth = GitHubAppAuth(asset)
+
+        with pytest.raises(ActionFailure):
+            github_app_auth._fetch_installation_token()
+
+
+class TestResolveGithubAuth:
+    def test_prefers_pat_over_github_app(self):
+        asset = _make_asset(personal_access_token="pat-token")
+        result = resolve_github_auth(asset)
+        assert result.__class__.__name__ == "StaticTokenAuth"
+
+    def test_uses_github_app_when_no_pat(self):
+        asset = _make_asset()
+        result = resolve_github_auth(asset)
+        assert isinstance(result, GitHubAppAuth)
+
+    def test_falls_back_to_oauth_app(self):
+        asset = _make_asset(app_id=None, app_private_key=None, app_installation_id=None)
+        asset.client_id = "client-id"
+        asset.client_secret = "client-secret"
+        asset.auth_state = {}
+        result = resolve_github_auth(asset)
+        assert result.__class__.__name__ == "OAuthBearerAuth"
+
+    def test_raises_when_unconfigured(self):
+        asset = _make_asset(app_id=None, app_private_key=None, app_installation_id=None)
+        with pytest.raises(ActionFailure):
+            resolve_github_auth(asset)
+
+
+class TestHasGithubAppConfig:
+    def test_true_when_fully_configured(self):
+        assert has_github_app_config(_make_asset()) is True
+
+    def test_false_when_partially_configured(self):
+        asset = _make_asset(app_installation_id=None)
+        assert has_github_app_config(asset) is False

--- a/uv.lock
+++ b/uv.lock
@@ -355,9 +355,10 @@ wheels = [
 
 [[package]]
 name = "github"
-version = "3.0.0"
+version = "3.0.1"
 source = { virtual = "." }
 dependencies = [
+    { name = "pyjwt", extra = ["crypto"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "splunk-soar-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
@@ -373,7 +374,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "splunk-soar-sdk", specifier = ">=3.22.2" }]
+requires-dist = [
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8.0" },
+    { name = "splunk-soar-sdk", specifier = ">=3.22.2" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Adds a third credential style to the GitHub asset alongside Personal Access Token and OAuth App: **GitHub App (installation) authentication**.

GitHub Apps authenticate by signing a short-lived JWT with the App's RSA private key, then exchanging that JWT for an installation access token. This is the recommended auth method for automated integrations acting on behalf of an installed GitHub App, and avoids the need for a long-lived personal access token or an interactive OAuth authorization flow.

## Changes

- **src/asset.py**: add pp_id, pp_private_key (sensitive), and pp_installation_id configuration fields.
- **src/auth.py**:
  - generate_github_app_jwt(asset) — builds and signs an RS256 JWT (iss/iat/exp per GitHub's App auth spec), normalizing common PEM copy/paste issues (BOM, literal \\n sequences, whitespace) and raising a clear ValueError if a public key or invalid PEM is supplied.
  - GitHubAppAuth — an httpx.Auth implementation that exchanges the JWT for an installation access token via POST /app/installations/{id}/access_tokens and caches it until shortly before expiry (5-minute buffer).
  - esolve_github_auth() priority order is now: personal_access_token → GitHub App → client_id/client_secret (OAuth App).
  - has_github_app_config(asset) helper.
- **src/actions/test_connectivity.py**: skip the interactive OAuth authorization flow when GitHub App credentials are configured (probes GET /user directly, same as PAT).
- **src/consts.py**: new endpoint/messages/timing constants for GitHub App auth.
- **pyproject.toml**: add pyjwt[crypto] dependency.
- **README.md**: document the three new configuration variables.
- **	ests/test_auth.py**: unit tests covering JWT generation/claims/signature verification, PEM normalization (BOM, escaped newlines, whitespace) and validation errors (public key, garbage input), installation token fetch/cache/refresh behavior, and esolve_github_auth priority ordering.

## Testing

- pytest tests/ — 25 passed
- uff check / uff format — clean

## Configuration example

\\\
app_id = 123456
app_private_key = -----BEGIN RSA PRIVATE KEY-----...-----END RSA PRIVATE KEY-----
app_installation_id = 78901234
\\\
