### PR TITLE
chore: sync uv.lock with project version

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fixed the uv.lock project version to match pyproject.toml for reliable locked dependency installation

--- a/uv.lock
+++ b/uv.lock
@@ -355,7 +355,7 @@ wheels = [
 
 [[package]]
 name = "github"
-version = "3.0.0"
+version = "3.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "splunk-soar-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
### Bug Fixes

- Synchronized the `github` root package version in `uv.lock` with version `3.0.1` in `pyproject.toml`.
- This prevents locked `uv` operations in the app-tests installation harness from failing because of the outdated lockfile.

### Manual Documentation

- [x] I have verified that no manual documentation updates are required.

### Other information

- The lockfile was regenerated using `uv 0.9.22` to preserve its existing format.
- The lockfile change is limited to the root package version.
- Added the required unreleased-note entry.
- The complete pre-commit suite passes.